### PR TITLE
Allow git branch to be configurable for github releases

### DIFF
--- a/.mod_data.yml.example
+++ b/.mod_data.yml.example
@@ -28,4 +28,4 @@ deploy:
     mod-id: 230112  # The CurseForge mod ID for deployment
   GitHub:
     enabled: true  # activate/deactivate this deployment script
-    mod-id: 230112  # The CurseForge mod ID for deployment
+    branch: main # The branch to release on. Defaults to "master"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ Deploy to Spacedock. You must supply a `mod-id` which is the numeric ID, as indi
 `CurseForge`
 Deploy to Curseforge. You must supply a `mod-id` which is the numeric ID of the project, as shown on the mod's webpage. You must provide the CurseForge-generated Oauth token (see [Getting Started](https://github.com/post-kerbin-mining-corporation/build-deploy/blob/master/docs/start.md))
 `GitHub`
-Deploy to GitHub releases. You must supply appropriate GitHub user information (see [Getting Started](https://github.com/post-kerbin-mining-corporation/build-deploy/blob/master/docs/start.md))
+Deploy to GitHub releases. You must supply appropriate GitHub user information (see [Getting Started](https://github.com/post-kerbin-mining-corporation/build-deploy/blob/master/docs/start.md)). You can optionally provide a `branch` to release on (defaults to "master").
 
 ```
 # Example annotated build data file
@@ -87,6 +87,7 @@ deploy:
       mod-id: 230112  # The CurseForge mod ID for deployment
   - GitHub:
       enabled: false  # activate/deactivate this deployment script
+      branch: main # The branch to release on. Defaults to "master"
 ```
 
 

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -57,8 +57,13 @@ def deploy(mod_data_file):
             config)
 
     if "GitHub" in build_data["deploy"] and build_data["deploy"]["GitHub"]["enabled"]:
+        branch = "master"
+        if "branch" in build_data["deploy"]["GitHub"]:
+            branch = build_data["deploy"]["GitHub"]["branch"]
+
         deploy_github(
             get_version(version_data),
+            branch,
             changelog,
             zipfile,
             config)
@@ -107,12 +112,13 @@ def deploy_spacedock(version, ksp_version, mod_id, changelog, zipfile, config):
     except requests.exceptions.ConnectionError as err:
         logger.warning(f"Skipping Spacedock deploy as Spacedock is down ({err})")
 
-def deploy_github(version, changelog, zipfile, config):
+def deploy_github(version, branch, changelog, zipfile, config):
     """
     Performs deployment to GitHub releases
 
     Inputs:
         version (str): mod version
+        branch (str): branch to release on
         changelog (str): Markdown formatted changelog
         zipfile (str): path to file to upload
         config (KSPConfiguration): configuration instance
@@ -153,8 +159,8 @@ def deploy_github(version, changelog, zipfile, config):
                 if do_upload:
                     logger.warning(f"Release already exists but has a missing asset, {zipfile} will be uploaded")
         else:
-            logger.info(f"Creating new release for version {version}")
-            response = api.create_release(version, changelog)
+            logger.info(f"Creating new release for version {version} on branch {branch}")
+            response = api.create_release(version, branch, changelog)
             release_id = response["id"]
             do_upload = True
 

--- a/src/ksp_deploy/github.py
+++ b/src/ksp_deploy/github.py
@@ -113,7 +113,7 @@ class GitHubReleasesAPI(object):
             "tag_name": version,
             "body": changelog,
             "name": f"{self.repo} {version}",
-            "target_commitish": "master",
+            #"target_commitish": "master",
             "draft": False,
             "prerelease": False
         }

--- a/src/ksp_deploy/github.py
+++ b/src/ksp_deploy/github.py
@@ -97,12 +97,13 @@ class GitHubReleasesAPI(object):
             self.logger.error(f"{resp.url} returned {resp.text}")
             return resp.text
 
-    def create_release(self, version, changelog):
+    def create_release(self, version, branch, changelog):
         """
         Creates a github release
 
         Inputs:
             version (str): the string mod version to use
+            branch (str): branch to release on
             changelog (str): a Markdown-formatted changelog
         Return:
             response (dict): json response from server
@@ -113,7 +114,7 @@ class GitHubReleasesAPI(object):
             "tag_name": version,
             "body": changelog,
             "name": f"{self.repo} {version}",
-            #"target_commitish": "master",
+            "target_commitish": branch,
             "draft": False,
             "prerelease": False
         }


### PR DESCRIPTION
Currently untested, adds an optional "branch" field to the Github target in `.mod_data.yml`, which defaults to "master" for backwards compatability. 
