### PR TITLE
Use current branch for commitish when deploying github release

### DIFF
--- a/src/deploy.py
+++ b/src/deploy.py
@@ -123,6 +123,7 @@ def deploy_github(version, changelog, zipfile, config):
     github_user = find_credentials("GITHUB_USER", config)
     github_token = find_credentials("GITHUB_OAUTH_TOKEN", config)
     repo_slug = os.environ["TRAVIS_REPO_SLUG"]
+    branch = os.environ["TRAVIS_BRANCH"]
 
     with GitHubReleasesAPI(github_user, github_token, repo_slug) as api:
 
@@ -154,9 +155,6 @@ def deploy_github(version, changelog, zipfile, config):
                 if do_upload:
                     logger.warning(f"Release already exists but has a missing asset, {zipfile} will be uploaded")
         else:
-            branch_cmd = "git branch --show-current"
-            branch = subprocess.check_output(branch_cmd, shell=True)
-
             logger.info(f"Creating new release for version {version} on branch {branch}")
             response = api.create_release(version, changelog, branch)
             release_id = response["id"]

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -4,7 +4,6 @@ import shutil
 import zipfile
 import zlib
 import requests
-import subprocess
 from argparse import ArgumentParser
 
 from ksp_deploy.config import KSPConfiguration

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -4,6 +4,7 @@ import shutil
 import zipfile
 import zlib
 import requests
+import subprocess
 from argparse import ArgumentParser
 
 from ksp_deploy.config import KSPConfiguration
@@ -122,6 +123,9 @@ def deploy_github(version, changelog, zipfile, config):
     github_user = find_credentials("GITHUB_USER", config)
     github_token = find_credentials("GITHUB_OAUTH_TOKEN", config)
     repo_slug = os.environ["TRAVIS_REPO_SLUG"]
+
+    branch_cmd = "git branch --show-current"
+    branch = subprocess.check_output(branch_cmd, shell=True)
 
     with GitHubReleasesAPI(github_user, github_token, repo_slug) as api:
 

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -124,9 +124,6 @@ def deploy_github(version, changelog, zipfile, config):
     github_token = find_credentials("GITHUB_OAUTH_TOKEN", config)
     repo_slug = os.environ["TRAVIS_REPO_SLUG"]
 
-    branch_cmd = "git branch --show-current"
-    branch = subprocess.check_output(branch_cmd, shell=True)
-
     with GitHubReleasesAPI(github_user, github_token, repo_slug) as api:
 
         latest = api.get_latest_release()
@@ -157,8 +154,11 @@ def deploy_github(version, changelog, zipfile, config):
                 if do_upload:
                     logger.warning(f"Release already exists but has a missing asset, {zipfile} will be uploaded")
         else:
-            logger.info(f"Creating new release for version {version}")
-            response = api.create_release(version, changelog)
+            branch_cmd = "git branch --show-current"
+            branch = subprocess.check_output(branch_cmd, shell=True)
+
+            logger.info(f"Creating new release for version {version} on branch {branch}")
+            response = api.create_release(version, changelog, branch)
             release_id = response["id"]
             do_upload = True
 

--- a/src/ksp_deploy/github.py
+++ b/src/ksp_deploy/github.py
@@ -97,7 +97,7 @@ class GitHubReleasesAPI(object):
             self.logger.error(f"{resp.url} returned {resp.text}")
             return resp.text
 
-    def create_release(self, version, changelog):
+    def create_release(self, version, changelog, branch):
         """
         Creates a github release
 
@@ -113,7 +113,7 @@ class GitHubReleasesAPI(object):
             "tag_name": version,
             "body": changelog,
             "name": f"{self.repo} {version}",
-            "target_commitish": "master",
+            "target_commitish": branch,
             "draft": False,
             "prerelease": False
         }


### PR DESCRIPTION
Github releases made through the API need a branch to compare against, independent of the actual tag that its linked to. Right now, this is hardcoded to "master", which causes issues on repos that don't have a branch named master. 

This PR fixes that by using the currently checked out branch that is being run on, as supplied by Travis.